### PR TITLE
Ensure channel is connected to if chatClient's connection cycles

### DIFF
--- a/src/services/platforms/twitch/chat/useChatClient.ts
+++ b/src/services/platforms/twitch/chat/useChatClient.ts
@@ -24,8 +24,10 @@ export default function useChatClient() {
 
     const chatClient = chatClientRef.current
     if (!chatClient.isConnected && !chatClient.isConnecting) {
+      chatClient.onConnect(() => {
+        chatClient.join(broadcaster!.userName)
+      })
       chatClient.connect()
-      chatClient.join(broadcaster!.userName)
     }
 
     // -------------------------


### PR DESCRIPTION
At current, if the websocket gets interrupted, chatClient will open a new connection to the Twitch IRC Websocket interface, but will not rejoin the broadcaster's channel