### PR TITLE
Emote modifiers

### DIFF
--- a/src/@types/betterttv.d.ts
+++ b/src/@types/betterttv.d.ts
@@ -12,6 +12,7 @@ namespace BetterTTV {
     code: string
     imageType: string
     animated: boolean
+    modifier: boolean
   }
 
   type ChannelEmote = Emote & {

--- a/src/@types/betterttv.d.ts
+++ b/src/@types/betterttv.d.ts
@@ -12,11 +12,14 @@ namespace BetterTTV {
     code: string
     imageType: string
     animated: boolean
-    modifier: boolean
   }
 
   type ChannelEmote = Emote & {
     userId: string
+  }
+
+  type GlobalEmote = ChannelEmote & {
+    modifier: boolean
   }
 
   type SharedEmote = Emote & {

--- a/src/@types/slime2.d.ts
+++ b/src/@types/slime2.d.ts
@@ -120,6 +120,7 @@ namespace Slime2 {
         name: string
         images: Emote.Images
         source: Emote.Source
+        isModifier: boolean
       }
 
       type EmoteMap = Map<string, Emote>

--- a/src/@types/twitch.d.ts
+++ b/src/@types/twitch.d.ts
@@ -107,7 +107,7 @@ namespace Twitch {
         type Type =
           | { type: 'text' }
           | { type: 'cheer'; cheer: Cheermote }
-          | { type: 'emote'; emote: Slime2.Event.Message.Emote }
+          | { type: 'emote'; emote: Slime2.Event.Message.Emote; modifier?: string }
       }
 
       type Cheermote = {

--- a/src/main.css
+++ b/src/main.css
@@ -129,3 +129,12 @@ html {
     opacity: 0;
   }
 }
+
+@keyframes slime2-emote-modifier-party {
+  from {
+    filter: sepia(0.5) hue-rotate(0deg) saturate(2.5);
+  }
+  to {
+    filter: sepia(0.5) hue-rotate(360deg) saturate(2.5);
+  }
+}

--- a/src/services/emotes/BetterTTV.ts
+++ b/src/services/emotes/BetterTTV.ts
@@ -10,6 +10,73 @@ export default async function getChannelEmotes(
 ): Promise<Slime2.Event.Message.EmoteMap> {
   const emoteMap = new Map<string, Slime2.Event.Message.Emote>()
 
+  setEmotes(<BetterTTV.ChannelEmote[]>[
+    {
+      id: "6468f7acaee1f7f47567708e",
+      code: "c!",
+      imageType: "png",
+      animated: false,
+      userId: "5561169bd6b9d206222a8c19",
+      modifier: true,
+    },
+    {
+      id: "6468f845aee1f7f47567709b",
+      code: "h!",
+      imageType: "png",
+      animated: false,
+      userId: "5561169bd6b9d206222a8c19",
+      modifier: true,
+    },
+    {
+      id: "6468f869aee1f7f4756770a8",
+      code: "l!",
+      imageType: "png",
+      animated: false,
+      userId: "5561169bd6b9d206222a8c19",
+      modifier: true,
+    },
+    {
+      id: "6468f883aee1f7f4756770b5",
+      code: "r!",
+      imageType: "png",
+      animated: false,
+      userId: "5561169bd6b9d206222a8c19",
+      modifier: true,
+    },
+    {
+      id: "6468f89caee1f7f4756770c2",
+      code: "v!",
+      imageType: "png",
+      animated: false,
+      userId: "5561169bd6b9d206222a8c19",
+      modifier: true,
+    },
+    {
+      id: "6468f8d1aee1f7f4756770cf",
+      code: "z!",
+      imageType: "png",
+      animated: false,
+      userId: "5561169bd6b9d206222a8c19",
+      modifier: true,
+    },
+    {
+      id: "64e3b31920cb0d25d950a9f9",
+      code: "w!",
+      imageType: "png",
+      animated: false,
+      userId: "5561169bd6b9d206222a8c19",
+      modifier: true,
+    },
+    {
+      id: "65cbe7dbaed093b2eaf87c65",
+      code: "p!",
+      imageType: "png",
+      animated: false,
+      userId: "5561169bd6b9d206222a8c19",
+      modifier: true,
+    }
+  ])
+
   const user = await bttvApi
     .get<BetterTTV.UserResponse>(`/users/${platform}/${userId}`)
     .then(response => response.data)
@@ -31,6 +98,7 @@ export default async function getChannelEmotes(
           static: buildEmoteUrls(emote.id, true),
         },
         source: 'betterttv',
+        isModifier: emote.modifier,
       })
     })
   }

--- a/src/services/emotes/BetterTTV.ts
+++ b/src/services/emotes/BetterTTV.ts
@@ -10,71 +10,71 @@ export default async function getChannelEmotes(
 ): Promise<Slime2.Event.Message.EmoteMap> {
   const emoteMap = new Map<string, Slime2.Event.Message.Emote>()
 
-  setEmotes(<BetterTTV.ChannelEmote[]>[
+  setEmotes(<BetterTTV.GlobalEmote[]>[
     {
-      id: "6468f7acaee1f7f47567708e",
-      code: "c!",
-      imageType: "png",
+      id: '6468f7acaee1f7f47567708e',
+      code: 'c!',
+      imageType: 'png',
       animated: false,
-      userId: "5561169bd6b9d206222a8c19",
+      userId: '5561169bd6b9d206222a8c19',
       modifier: true,
     },
     {
-      id: "6468f845aee1f7f47567709b",
-      code: "h!",
-      imageType: "png",
+      id: '6468f845aee1f7f47567709b',
+      code: 'h!',
+      imageType: 'png',
       animated: false,
-      userId: "5561169bd6b9d206222a8c19",
+      userId: '5561169bd6b9d206222a8c19',
       modifier: true,
     },
     {
-      id: "6468f869aee1f7f4756770a8",
-      code: "l!",
-      imageType: "png",
+      id: '6468f869aee1f7f4756770a8',
+      code: 'l!',
+      imageType: 'png',
       animated: false,
-      userId: "5561169bd6b9d206222a8c19",
+      userId: '5561169bd6b9d206222a8c19',
       modifier: true,
     },
     {
-      id: "6468f883aee1f7f4756770b5",
-      code: "r!",
-      imageType: "png",
+      id: '6468f883aee1f7f4756770b5',
+      code: 'r!',
+      imageType: 'png',
       animated: false,
-      userId: "5561169bd6b9d206222a8c19",
+      userId: '5561169bd6b9d206222a8c19',
       modifier: true,
     },
     {
-      id: "6468f89caee1f7f4756770c2",
-      code: "v!",
-      imageType: "png",
+      id: '6468f89caee1f7f4756770c2',
+      code: 'v!',
+      imageType: 'png',
       animated: false,
-      userId: "5561169bd6b9d206222a8c19",
+      userId: '5561169bd6b9d206222a8c19',
       modifier: true,
     },
     {
-      id: "6468f8d1aee1f7f4756770cf",
-      code: "z!",
-      imageType: "png",
+      id: '6468f8d1aee1f7f4756770cf',
+      code: 'z!',
+      imageType: 'png',
       animated: false,
-      userId: "5561169bd6b9d206222a8c19",
+      userId: '5561169bd6b9d206222a8c19',
       modifier: true,
     },
     {
-      id: "64e3b31920cb0d25d950a9f9",
-      code: "w!",
-      imageType: "png",
+      id: '64e3b31920cb0d25d950a9f9',
+      code: 'w!',
+      imageType: 'png',
       animated: false,
-      userId: "5561169bd6b9d206222a8c19",
+      userId: '5561169bd6b9d206222a8c19',
       modifier: true,
     },
     {
-      id: "65cbe7dbaed093b2eaf87c65",
-      code: "p!",
-      imageType: "png",
+      id: '65cbe7dbaed093b2eaf87c65',
+      code: 'p!',
+      imageType: 'png',
       animated: false,
-      userId: "5561169bd6b9d206222a8c19",
+      userId: '5561169bd6b9d206222a8c19',
       modifier: true,
-    }
+    },
   ])
 
   const user = await bttvApi
@@ -98,7 +98,8 @@ export default async function getChannelEmotes(
           static: buildEmoteUrls(emote.id, true),
         },
         source: 'betterttv',
-        isModifier: emote.modifier,
+        isModifier:
+          'modifier' in emote ? (<BetterTTV.GlobalEmote>emote).modifier : false,
       })
     })
   }

--- a/src/services/emotes/FrankerFaceZ.ts
+++ b/src/services/emotes/FrankerFaceZ.ts
@@ -33,6 +33,7 @@ export default async function getChannelEmotes(
           static: buildEmoteUrls(emote, true),
         },
         source: 'frankerfacez',
+        isModifier: false,
       })
     })
   })

--- a/src/services/emotes/YouTube.ts
+++ b/src/services/emotes/YouTube.ts
@@ -11,6 +11,7 @@ export function getGlobalEmotes(): Slime2.Event.Message.EmoteMap {
         static: buildEmoteUrls(emoji.image),
       },
       source: 'youtube',
+      isModifier: false,
     })
   })
 

--- a/src/services/platforms/twitch/chat/transforms/useEmotePart.ts
+++ b/src/services/platforms/twitch/chat/transforms/useEmotePart.ts
@@ -41,6 +41,7 @@ export function useEmotePart() {
           static: buildEmoteUrls(id, true),
         },
         source: 'twitch',
+        isModifier: false,
       },
     }
   }

--- a/src/services/platforms/twitch/chat/transforms/useMessage.ts
+++ b/src/services/platforms/twitch/chat/transforms/useMessage.ts
@@ -6,9 +6,9 @@ import useUser from './useUser'
 /**
  * Hook that returns the function {@link transform}
  */
-export default function useMessage() {
+export default function useMessage(enableEmoteModifiers: boolean = false) {
   const { data: channelPointRewards } = useChannelPointRewards()
-  const transformText = useText()
+  const transformText = useText(enableEmoteModifiers)
   const transformUser = useUser()
 
   /**

--- a/src/services/platforms/twitch/chat/transforms/useText.ts
+++ b/src/services/platforms/twitch/chat/transforms/useText.ts
@@ -56,9 +56,9 @@ export default function useText(enableEmoteModifiers: boolean = false) {
           if (
             i + 1 < parts.length &&
             parts[i + 1].type === 'text' &&
-            parts[i + 1].text === ' '
+            parts[i + 1].text.trim() === ''
           ) {
-            // drop space seperating modifier from following emote
+            // Drop whitespace seperating the modifier from the following emote
             parts.splice(i + 1, 1)
           }
         } else if (emoteModifiersQueued.length > 0) {
@@ -90,18 +90,18 @@ export default function useText(enableEmoteModifiers: boolean = false) {
                 break
               case 'w!': // Wide
                 part.modifier += 'transform: scaleX(3);'
-                // BTTV hardcodes emote size to make widened emote spacing work.
-                // Instead, we add blank emotes before and after this emote, for easy spacing no matter what widget
+                // We can't hardcod emote size to make widened emote spacing work.
+                // Instead, add blank emotes before and after this emote, for easy spacing no matter what widget
                 parts.splice(i + 1, 0, BLANK_EMOTE_PART)
                 parts.splice(i, 0, BLANK_EMOTE_PART)
                 i += 1
                 break
               case 'z!': // Zero Space
-                // Simply remove the space-only text part before this emote
+                // Simply remove the whitespace-only text part before this emote
                 if (
                   i - 1 < parts.length &&
                   parts[i - 1].type === 'text' &&
-                  parts[i - 1].text === ' '
+                  parts[i - 1].text.trim() === ''
                 ) {
                   parts.splice(i - 1, 1)
                 }

--- a/src/services/platforms/twitch/chat/transforms/useText.ts
+++ b/src/services/platforms/twitch/chat/transforms/useText.ts
@@ -7,7 +7,7 @@ import { useTextPart } from './useTextPart'
 /**
  * Hook that returns the function {@link transform}
  */
-export default function useText() {
+export default function useText(enableEmoteModifiers: boolean = false) {
   const { data: cheermotes } = useCheermotes()
   const transformTextPart = useTextPart()
   const transformCheerPart = useCheerPart()
@@ -47,8 +47,102 @@ export default function useText() {
       }
     })
 
+    let emoteModifiersQueued: Slime2.Event.Message.Emote[] = []
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]
+      if (part.type === 'emote') {
+        if (part.emote.isModifier) {
+          emoteModifiersQueued.push(part.emote)
+          if (
+            i + 1 < parts.length &&
+            parts[i + 1].type === 'text' &&
+            parts[i + 1].text === ' '
+          ) {
+            // drop space seperating modifier from following emote
+            parts.splice(i + 1, 1)
+          }
+        } else if (emoteModifiersQueued.length > 0) {
+          i -= emoteModifiersQueued.length
+          parts.splice(i, emoteModifiersQueued.length)
+
+          part.modifier = ''
+          emoteModifiersQueued.forEach(emote => {
+            switch (emote.name) {
+              case 'c!': // Cursed
+                part.modifier +=
+                  'filter: grayscale(1) brightness(.7) contrast(2.5);'
+                break
+              case 'h!': // Horizontal Flip
+                part.modifier += 'transform: scaleX(-1);'
+                break
+              case 'l!': // Left Rotate
+                part.modifier += 'transform: rotate(-90deg);'
+                break
+              case 'p!': // Party
+                part.modifier +=
+                  'animation: slime2-emote-modifier-party 1.5s linear infinite;'
+                break
+              case 'r!': // Right Rotate
+                part.modifier += 'transform: rotate(90deg);'
+                break
+              case 'v!': // Vertical Flip
+                part.modifier += 'transform: scaleY(-1);'
+                break
+              case 'w!': // Wide
+                part.modifier += 'transform: scaleX(3);'
+                // BTTV hardcodes emote size to make widened emote spacing work.
+                // Instead, we add blank emotes before and after this emote, for easy spacing no matter what widget
+                parts.splice(i + 1, 0, BLANK_EMOTE_PART)
+                parts.splice(i, 0, BLANK_EMOTE_PART)
+                i += 1
+                break
+              case 'z!': // Zero Space
+                // Simply remove the space-only text part before this emote
+                if (
+                  i - 1 < parts.length &&
+                  parts[i - 1].type === 'text' &&
+                  parts[i - 1].text === ' '
+                ) {
+                  parts.splice(i - 1, 1)
+                }
+                break
+            }
+          })
+          emoteModifiersQueued = []
+
+          if (part.modifier === '') part.modifier = undefined
+        }
+      } else if (emoteModifiersQueued.length > 0) {
+        emoteModifiersQueued = []
+      }
+    }
+    console.log(parts)
+
     return parts
   }
 
   return transform
+}
+
+const BLANK_EMOTE_PART: Twitch.Event.Message.Part = {
+  type: 'emote',
+  text: '',
+  emote: {
+    id: '',
+    name: ':blank:',
+    images: {
+      default: {
+        x1: 'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+        x2: 'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+        x4: 'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+      },
+      static: {
+        x1: 'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+        x2: 'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+        x4: 'data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+      },
+    },
+    source: 'betterttv',
+    isModifier: false,
+  },
 }

--- a/src/services/platforms/twitch/chat/useEmulate.ts
+++ b/src/services/platforms/twitch/chat/useEmulate.ts
@@ -41,7 +41,7 @@ export default function useEmulateTwitchMessage() {
     const emotes = [
       ...channelEmotes!,
       ...Array.from(thirdPartyEmoteMap!.values()),
-    ]
+    ].filter(e => !e.isModifier)
 
     const date = new Date()
     const first = Random.chance(5) // 5% chance of being first time chat

--- a/src/services/platforms/twitch/useChannelEmotes.ts
+++ b/src/services/platforms/twitch/useChannelEmotes.ts
@@ -23,6 +23,7 @@ export default function useChannelEmotes() {
             static: buildEmoteUrls(id, true),
           },
           source: 'twitch',
+          isModifier: false,
         }
       })
     },


### PR DESCRIPTION
Hi! I've implemented BTTV emote modifiers in Twitch message parsing, so they can be displayed in chat widgets. This is more of a proof of concept right now, hence the Draft PR - I'm submitting this mainly to check whether this is something you want implemented in base slime2, and if yes, what your thoughts on a couple of problems would be.

Currently, this feature works by hardcoding the modifier emotes into the emote map returned by the BTTV service. Then it iterates over the parsed message `Part`s, removing modifier emotes and applying the styling to the following target emote (ignoring any whitespace-only text-type `Part`s).  
The styling is returned as a string of CSS in the emote-type `Part`, so widgets can support modifiers by simply assigning that string to the `style` attribute of their emote elements.
If the style info is not used by the widget, (valid) modifier emotes will be hidden and the target emotes will be unaffected. Widgets could offer an "Enable Emote Modifiers" setting this way, by simply ignoring style info if it is not wanted. (The only exception is `z!` which works without styling, it just removes the text `Part` between the emotes.)

![Example screenshot, showing all BTTV modifiers applied to an emote](https://github.com/zaytri/slime2/assets/5811591/a5f7dbc7-6bdf-4176-8e41-5302828424c8)
```
KotoBomb h! KotoBomb v! KotoBomb l! KotoBomb r! KotoBomb
c! KotoBomb p! KotoBomb KotoBomb z! KotoBomb
w! KotoBomb w! c! KotoBomb
```

Some open todos/questions:

- The modifier emote list is currently hardcoded. Would it be better to fetch the BTTV global emotes list, but filter out all non-modifier emotes, to make sure it works fine even if IDs change or future modifiers are still hidden on widgets while unimplemented?
- It would also probably be smarter to make the modifier styles CSS classes and only return the class names to be added to the emote elements, instead of concatenating the style strings in the parser...
- Since this might be useful for YouTube chat as well in the future, would it be useful to implement this as a seperate service that can be used on both sites? The `Part` type could be possible to share between the chats, I think.
- Should this handle FFZ modifiers as well? These modifier emotes are called effect emotes there, and work a little differently in terms of setting them up (`modifier_flags` bitmask instead of just by emote name), but are generally also just filters, transforms and animations, so it probably would work just fine.
- The `w!` modifier works right now by adding blank emotes before and after the scaled emote to make sure that no matter what size the widget renders emotes in, the correct amount of space is reserved. Well, only for square emotes right now - but I think that can be changed by making the blank emotes copies of the widened emote, and adding an internal-only "hidden" modifier to them so they aren't rendered.
- A big problem right now with `w!` and `z!` is line breaks. The blank emotes for `w!` can end up in different lines and mess with the spacing that way, and `z!` cannot guarantee the emotes will be on the same line, so they might not actually be joined. I can't think of a way to avoid a line break with just CSS.
- The one modifier I have no idea how to implement is emotes overlaid over another ("modifier emotes" in FFZ, and has a PR going in the BTTV repo as `o!`). The overlaying itself could be just a `transform: translateX(-100%)`, but that would leave the empty space, and result in another possible line break problem.
- Fixing the problems with these modifiers would require additional functionality to be implemented in the widgets instead of pure CSS as it currently is. I'm not sure though, what would be the easiest to implement for widget developers, to reduce the amount of changes they have to make to enable modifiers?
  - For `w!` and `o!`, one solution could be to simply add a class to the emotes and having widget developers implement the CSS rules depending on their chosen emote height. This would solve most line break problems (widened emotes could be just a single element, overlaying emotes could use margins), but it wouldn't solve the issue for `z!`.
  - Another possibility would be to be able to insert zero-width non-breaking spaces between emotes. I can't use a text-type `Part` as it will be nested in a `span` - this would require some sort of alternative text `Part`, which widget developers must render without any surrounding element, so it could be handled by the browser correctly. While that would solve the line break problems, it doesn't help with overlaying emotes for `o!`.
  - A flexible solution would be to add something like a "combined emotes `Part`", and widget developers would have to add functionality to render these as a `div` element with the emotes inside. You could then apply any CSS rules to the outer container - a no-wrap for `w!` and `z!`, or a rule that absolutely positions children for `o!`. I think this might potentially cause troubles with vertical alignment, though, but it seems like the best approach to me.

Looking forward to hearing your thoughts!